### PR TITLE
Migrate Existing API

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	facebookLib "github.com/huandu/facebook"
+)
+
+const facebookAPIVersion = "v2.7"
+
+type (
+	// API comment pending
+	API struct {
+		Session     *facebookLib.Session
+		AccessToken string
+	}
+)
+
+// NewAPI comment pending
+func NewAPI() API {
+	api := API{&facebookLib.Session{}, ""}
+	api.Session.Version = FACEBOOK_API_VERSION
+	return api
+}
+
+// Batch comment pending
+func (f *API) Batch(params ...facebookLib.Params) ([]*APIResponse, *Error) {
+	var apiResponses []*APIResponse
+
+	results, err := f.Session.BatchApi(params...)
+
+	if err != nil {
+		return []*APIResponse{}, NewError(err)
+	}
+
+	for _, result := range results {
+		batch, err := result.Batch()
+
+		if err != nil {
+			return []*APIResponse{}, NewError(err)
+		}
+
+		apiResponse := NewAPIResponse(f, &batch.Result)
+		apiResponses = append(apiResponses, apiResponse)
+	}
+
+	return apiResponses, nil
+}
+
+//Get comment pending
+func (f *API) Get(path string, params facebookLib.Params) (*APIResponse, *Error) {
+	results, err := f.Session.Get(path, params)
+
+	if err != nil {
+		wrappedError := NewError(err)
+		return nil, wrappedError
+	}
+
+	return NewAPIResponse(f, &results), nil
+}
+
+// SetAccessToken comment pending
+func (f *API) SetAccessToken(accessToken string) {
+	f.Session.SetAccessToken(accessToken)
+	f.AccessToken = accessToken
+}

--- a/api.go
+++ b/api.go
@@ -17,7 +17,7 @@ type (
 // NewAPI comment pending
 func NewAPI() API {
 	api := API{&facebookLib.Session{}, ""}
-	api.Session.Version = FACEBOOK_API_VERSION
+	api.Session.Version = facebookAPIVersion
 	return api
 }
 

--- a/api_response.go
+++ b/api_response.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	facebookLib "github.com/huandu/facebook"
+)
+
+type (
+	// APIResponse comment pending
+	APIResponse struct {
+		*API
+		Result      *facebookLib.Result
+		PagedResult *facebookLib.PagingResult
+		Page        int
+	}
+)
+
+// NewAPIResponse comment pending
+func NewAPIResponse(facebookAPI *API, results *facebookLib.Result) *APIResponse {
+	return &APIResponse{
+		facebookAPI,
+		results,
+		nil,
+		1,
+	}
+}
+
+// Data comment pending
+func (a *APIResponse) Data(paginate bool) ([]facebookLib.Result, error) {
+	if paginate {
+		if a.PagedResult == nil {
+			paging, err := a.Result.Paging(a.Session)
+			if err != nil {
+				return []facebookLib.Result{}, err
+			}
+
+			a.PagedResult = paging
+		} else {
+			a.PagedResult.Next()
+		}
+
+		a.Page++
+		return a.PagedResult.Data(), nil
+	}
+
+	var results []facebookLib.Result
+	results = append(results, *a.Result)
+
+	return results, nil
+}
+
+// HasResults comment pending
+func (a *APIResponse) HasResults() bool {
+	if a.PagedResult == nil {
+		return true
+	}
+	return a.PagedResult.HasNext()
+}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"regexp"
+)
+
+type (
+	// Error pending comment
+	Error struct {
+		Error string
+	}
+)
+
+// NewError comment pending
+func NewError(err error) *Error {
+	return &Error{err.Error()}
+}
+
+// IsRateLimited comment pending
+func (e *Error) IsRateLimited() bool {
+	rateLimit := regexp.MustCompile(`\(#17\)$`)
+	return rateLimit.MatchString(e.Error)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,6 @@
+hash: 6882f1340bec7fca986364b3e7b9eb49f137cdbfaf19d730e408abeb40f4136e
+updated: 2016-08-01T17:51:35.665867276+01:00
+imports:
+- name: github.com/huandu/facebook
+  version: e7512237e5dc620be55f6bd9ab2d75e7ebbb914c
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,3 @@
+package: github.com/vidsy/fb-integration
+import:
+- package: github.com/huandu/facebook


### PR DESCRIPTION
### Problem

Can't share the FB wrapper we use in a service with other services...

### Solution

Migrate @stevenjack's existing codebase.

### Notes

- https://trello.com/c/IfM1y2A6/104-fbi-migrate-existing-api-structs